### PR TITLE
Feature/update to 1.29.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ networks:
 #SERVICES
 services:
   bitwarden:
-    image: vaultwarden/server:1.28.1-alpine
+    image: vaultwarden/server:1.29.1-alpine
     security_opt:
       - no-new-privileges:true
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,15 +31,6 @@ services:
       - traefik.http.routers.bitwarden-ui-http.middlewares=redirect-https
       - traefik.http.routers.bitwarden-ui-http.service=bitwarden-ui
       - traefik.http.services.bitwarden-ui.loadbalancer.server.port=80
-      - traefik.http.routers.bitwarden-websocket-https.rule=Host(`sub.my-domain.tld`) && Path(`/notifications/hub`)
-      - traefik.http.routers.bitwarden-websocket-https.entrypoints=https
-      - traefik.http.routers.bitwarden-websocket-https.tls=true
-      - traefik.http.routers.bitwarden-websocket-https.service=bitwarden-websocket
-      - traefik.http.routers.bitwarden-websocket-http.rule=Host(`sub.my-domain.tld`) && Path(`/notifications/hub`)
-      - traefik.http.routers.bitwarden-websocket-http.entrypoints=http
-      - traefik.http.routers.bitwarden-websocket-http.middlewares=redirect-https
-      - traefik.http.routers.bitwarden-websocket-http.service=bitwarden-websocket
-      - traefik.http.services.bitwarden-websocket.loadbalancer.server.port=3012
 
     volumes:
       # Stockage des fichiers Let's encrypt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3'
 networks:
   proxy:
     external: true
-  vaultinternal:
 
 #SERVICES
 services:
@@ -13,7 +12,6 @@ services:
       - no-new-privileges:true
     networks:
       - proxy
-      - vaultinternal
     environment:
       # After you setted up your user(s)
       - "SIGNUPS_ALLOWED=false"


### PR DESCRIPTION
vaultwarden to 1.29.1-alpine :
    - removed websocket labels for traefik not usefull anymore
    - removed network internal for websocket not usefull anymore